### PR TITLE
feat: add subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # java-explore-with-me
-Template repository for ExploreWithMe project.
+Ссылка на PR: https://github.com/Chizhara/java-explore-with-me/pull/8#issue-1977965718

--- a/explore-with-me-main_service/src/main/java/ru/practicum/controller/event/AdminEventController.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/controller/event/AdminEventController.java
@@ -10,6 +10,7 @@ import ru.practicum.mapper.EventMapper;
 import ru.practicum.model.event.EventState;
 import ru.practicum.model.event.UpdateEventRequest;
 import ru.practicum.model.event.dto.EventFullDto;
+import ru.practicum.param.EventParam;
 import ru.practicum.service.EventService;
 
 import javax.validation.Valid;
@@ -49,8 +50,15 @@ public class AdminEventController {
                             rangeStart, rangeEnd));
         }
 
+        EventParam eventParam = new EventParam();
+        eventParam.setInitiatorsId(usersId);
+        eventParam.setStates(states);
+        eventParam.setCategoriesId(categoriesId);
+        eventParam.setRangeStart(rangeStart);
+        eventParam.setRangeEnd(rangeEnd);
+
         return eventMapper.toEventFullDto(
-                eventService.searchEvents(usersId, states, categoriesId, rangeStart, rangeEnd, from, size));
+                eventService.searchEvents(eventParam, from, size));
     }
 
     @PatchMapping("/{eventId}")

--- a/explore-with-me-main_service/src/main/java/ru/practicum/controller/event/PrivateEventController.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/controller/event/PrivateEventController.java
@@ -14,6 +14,8 @@ import ru.practicum.model.event.dto.NewEventDto;
 import ru.practicum.service.EventService;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 import java.util.Collection;
 
 @Slf4j
@@ -28,8 +30,8 @@ public class PrivateEventController {
 
     @GetMapping
     public Collection<EventShortDto> getEvents(@PathVariable Long userId,
-                                               @RequestParam(defaultValue = "0") int from,
-                                               @RequestParam(defaultValue = "10") int size) {
+                                               @RequestParam(defaultValue = "0") @PositiveOrZero int from,
+                                               @RequestParam(defaultValue = "10") @Positive int size) {
         log.info("Invoked method getEvents of class PrivateEventController " +
                 "with parameters: userId = {}, from = {}, size = {};", userId, from, size);
         return eventMapper.toEventShortDto(

--- a/explore-with-me-main_service/src/main/java/ru/practicum/controller/event/PublicEventController.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/controller/event/PublicEventController.java
@@ -10,6 +10,7 @@ import ru.practicum.model.event.EventSort;
 import ru.practicum.model.event.EventState;
 import ru.practicum.model.event.dto.EventFullDto;
 import ru.practicum.model.event.dto.EventShortDto;
+import ru.practicum.param.EventParam;
 import ru.practicum.service.EventService;
 import ru.practicum.service.impl.StatService;
 
@@ -58,9 +59,17 @@ public class PublicEventController {
                             rangeStart, rangeEnd));
         }
 
+        EventParam eventParam = new EventParam();
+        eventParam.setSearchingText(text);
+        eventParam.setPaid(paid);
+        eventParam.setOnlyAvailable(onlyAvailable);
+        eventParam.setSort(sort);
+        eventParam.setCategoriesId(categoriesId);
+        eventParam.setRangeStart(rangeStart);
+        eventParam.setRangeEnd(rangeEnd);
+
         Collection<EventShortDto> events = eventMapper.toEventShortDto(
-                eventService.searchEvents(text, categoriesId, paid,
-                        rangeStart, rangeEnd, onlyAvailable, sort, from, size));
+                eventService.searchEvents(eventParam, from, size));
 
         statService.save();
         return events;

--- a/explore-with-me-main_service/src/main/java/ru/practicum/controller/user/PrivateSubscriberController.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/controller/user/PrivateSubscriberController.java
@@ -1,0 +1,81 @@
+package ru.practicum.controller.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import ru.practicum.mapper.EventMapper;
+import ru.practicum.mapper.UserMapper;
+import ru.practicum.model.event.dto.EventShortDto;
+import ru.practicum.model.user.dto.UserShortDto;
+import ru.practicum.param.EventParam;
+import ru.practicum.service.SubscriptionService;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+@Slf4j
+@RestController
+@RequestMapping(path = "/users/{userId}/subscriptions")
+@RequiredArgsConstructor
+@Validated
+public class PrivateSubscriberController {
+
+    private final SubscriptionService subscriptionService;
+    private final UserMapper userMapper;
+    private final EventMapper eventMapper;
+
+    @GetMapping
+    public Collection<UserShortDto> getSubscriptions(@PathVariable Long userId,
+                                                     @RequestParam(defaultValue = "0") @PositiveOrZero int from,
+                                                     @RequestParam(defaultValue = "10") @Positive int size) {
+        log.info("Invoked method getUsersByCommonEvents of class PrivateSubscriberController " +
+                "with parameters: userId = {}, from = {}, size = {};", userId, from, size);
+        return userMapper.toUserShortDto(subscriptionService.getSubscriptions(userId, from, size));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserShortDto postSubscription(@PathVariable Long userId, @RequestParam("initiatorId") Long subId) {
+        log.info("Invoked method postSubscription of class PrivateSubscriberController " +
+                "with parameters: userId = {}, subId = {};", userId, subId);
+        return userMapper.toUserShortDto(subscriptionService.addSubscription(userId, subId));
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteSubscription(@PathVariable Long userId, @RequestParam("initiatorId") Long subId) {
+        log.info("Invoked method deleteSubscription of class PrivateSubscriberController " +
+                "with parameters: userId = {}, subId = {};", userId, subId);
+        subscriptionService.removeSubscription(userId, subId);
+    }
+
+    @GetMapping("/events")
+    public Collection<EventShortDto> getSubscriberEvents(
+            @PathVariable Long userId,
+            @RequestParam(name = "categories", required = false) Collection<Long> categoriesId,
+            @RequestParam(name = "subscriptions", required = false) Collection<Long> subscriptionsId,
+            @RequestParam(defaultValue = "true") Boolean onlyAvailable,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime rangeStart,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime rangeEnd,
+            @RequestParam(defaultValue = "0") @PositiveOrZero int from,
+            @RequestParam(defaultValue = "10") @Positive int size) {
+        log.info("Invoked method getSubscriberEvents of class PrivateSubscriberController " +
+                        "with parameters: subId = {}, categoriesId = {}, onlyAvailable = {}, " +
+                        "rangeStart = {}, rangeEnd = {}, from = {}, size = {};",
+                userId, categoriesId, onlyAvailable, rangeStart, rangeEnd, from, size);
+
+        EventParam eventParam = new EventParam();
+        eventParam.setCategoriesId(categoriesId);
+        eventParam.setRangeStart(rangeStart);
+        eventParam.setRangeEnd(rangeEnd);
+        eventParam.setOnlyAvailable(onlyAvailable);
+        eventParam.setInitiatorsId(subscriptionsId);
+
+        return eventMapper.toEventShortDto(subscriptionService.getSubscriptionEvents(userId, eventParam, from, size));
+    }
+}

--- a/explore-with-me-main_service/src/main/java/ru/practicum/controller/user/PrivateUserController.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/controller/user/PrivateUserController.java
@@ -1,0 +1,43 @@
+package ru.practicum.controller.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import ru.practicum.mapper.UserMapper;
+import ru.practicum.model.user.dto.UserShortDto;
+import ru.practicum.service.SubscriptionService;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import java.util.Collection;
+
+@Slf4j
+@RestController
+@RequestMapping(path = "/users/{userId}")
+@RequiredArgsConstructor
+public class PrivateUserController {
+
+    private final SubscriptionService subscriptionService;
+    private final UserMapper userMapper;
+
+    @GetMapping("/subscribers")
+    public Collection<UserShortDto> getSubscribers(@PathVariable Long userId,
+                                                   @RequestParam(defaultValue = "0") @PositiveOrZero int from,
+                                                   @RequestParam(defaultValue = "10") @Positive int size) {
+        log.info("Invoked method getSubscribers of class PrivateUserController " +
+                "with parameters: userId = {}, from = {}, size = {};", userId, from, size);
+        return userMapper.toUserShortDto(subscriptionService.getSubscribers(userId, from, size));
+    }
+
+    @GetMapping("/initiators")
+    public Collection<UserShortDto> getInitiators(@PathVariable Long userId,
+                                                  @RequestParam(defaultValue = "true") Boolean onlyAliens,
+                                                  @RequestParam(defaultValue = "0") int from,
+                                                  @RequestParam(defaultValue = "10") int size) {
+        log.info("Invoked method getInitiators of class PrivateUserController " +
+                "with parameters: userId = {}, onlyAliens = {}, from = {}, size = {};", userId, onlyAliens, from, size);
+        return userMapper.toUserShortDto(subscriptionService.getInitiators(userId, onlyAliens, from, size));
+    }
+
+
+}

--- a/explore-with-me-main_service/src/main/java/ru/practicum/mapper/UserMapper.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/mapper/UserMapper.java
@@ -16,6 +16,8 @@ public interface UserMapper {
 
     Collection<UserDto> toUserDto(Collection<User> users);
 
+    Collection<UserShortDto> toUserShortDto(Collection<User> users);
+
     UserShortDto toUserShortDto(User user);
 
     @Mapping(target = "id", ignore = true)

--- a/explore-with-me-main_service/src/main/java/ru/practicum/model/compilation/EventsCompilation.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/model/compilation/EventsCompilation.java
@@ -5,6 +5,7 @@ import ru.practicum.model.event.Event;
 
 import javax.persistence.*;
 import java.util.Collection;
+import java.util.HashSet;
 
 @Entity
 @Table(name = "compilations", schema = "public")
@@ -25,7 +26,7 @@ public class EventsCompilation {
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "events_compilations", joinColumns = {@JoinColumn(name = "compilation_id")},
             inverseJoinColumns = @JoinColumn(name = "event_id"))
-    private Collection<Event> events;
+    private Collection<Event> events = new HashSet<>();
 
     @Override
     public String toString() {

--- a/explore-with-me-main_service/src/main/java/ru/practicum/model/user/User.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/model/user/User.java
@@ -3,6 +3,7 @@ package ru.practicum.model.user;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.Collection;
 
 @Entity
 @Table(name = "users", schema = "public")
@@ -20,6 +21,14 @@ public class User {
     String name;
     @Column(name = "email", unique = true)
     String email;
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "subscriptions", joinColumns = {@JoinColumn(name = "subscriber_id")},
+            inverseJoinColumns = @JoinColumn(name = "recipient_id"))
+    Collection<User> subscriptions;
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "subscriptions", joinColumns = {@JoinColumn(name = "recipient_id")},
+            inverseJoinColumns = @JoinColumn(name = "subscriber_id"))
+    Collection<User> subscribers;
 
     @Override
     public String toString() {

--- a/explore-with-me-main_service/src/main/java/ru/practicum/param/EventParam.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/param/EventParam.java
@@ -1,0 +1,94 @@
+package ru.practicum.param;
+
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.Expressions;
+import lombok.Data;
+import ru.practicum.model.event.EventSort;
+import ru.practicum.model.event.EventState;
+import ru.practicum.model.event.QEvent;
+import ru.practicum.model.user.User;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+@Data
+public class EventParam {
+
+    private final List<Predicate> predicates = new LinkedList<>();
+    private EventSort sort = EventSort.NONE;
+    private Collection<Long> initiatorsId;
+
+    public void setSearchingText(String searchingText) {
+        if (searchingText != null) {
+            predicates.add(QEvent.event.annotation.containsIgnoreCase(searchingText)
+                    .or(QEvent.event.description.containsIgnoreCase(searchingText)));
+        }
+    }
+
+    public void setOnlyAvailable(Boolean onlyAvailable) {
+        if (onlyAvailable != null && onlyAvailable) {
+            predicates.add(QEvent.event.participantLimit.eq(0)
+                    .or(QEvent.event.confirmedRequests.size().loe(QEvent.event.participantLimit)));
+        }
+    }
+
+    public void setInitiatorsId(Collection<Long> initiatorsId) {
+        if (initiatorsId != null) {
+            this.initiatorsId = initiatorsId;
+            predicates.add(QEvent.event.initiator.id.in(initiatorsId));
+        }
+    }
+
+    public void setCategoriesId(Collection<Long> categoriesId) {
+        if (categoriesId != null) {
+            predicates.add(QEvent.event.category.id.in(categoriesId));
+        }
+    }
+
+    public void setRangeEnd(LocalDateTime rangeEnd) {
+        if (rangeEnd != null) {
+            predicates.add(QEvent.event.eventDate.before(rangeEnd));
+        }
+    }
+
+    public void setStates(EventState... states) {
+        if (states != null) {
+            predicates.add(QEvent.event.state.in(states));
+        }
+    }
+
+    public void setStates(Collection<EventState> states) {
+        if (states != null) {
+            predicates.add(QEvent.event.state.in(states));
+        }
+    }
+
+    public void setRangeStart(LocalDateTime rangeStart) {
+        if (rangeStart != null) {
+            predicates.add(QEvent.event.eventDate.after(rangeStart));
+        }
+
+    }
+
+    public void setPaid(Boolean paid) {
+        if (paid != null) {
+            predicates.add(QEvent.event.paid.eq(paid));
+        }
+    }
+
+    public Predicate getExpression() {
+        if (predicates.isEmpty()) {
+            return Expressions.asBoolean(true).isTrue();
+        }
+        return ExpressionUtils.allOf(predicates);
+    }
+
+    public void setBySubscriber(User user) {
+        if (user != null) {
+            predicates.add(QEvent.event.initiator.subscribers.contains(user));
+        }
+    }
+}

--- a/explore-with-me-main_service/src/main/java/ru/practicum/repository/UserRepository.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/repository/UserRepository.java
@@ -1,8 +1,30 @@
 package ru.practicum.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import ru.practicum.model.event.EventState;
 import ru.practicum.model.user.User;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+import java.util.Collection;
 
+public interface UserRepository extends JpaRepository<User, Long> {
+    Page<User> findAllBySubscriptionsContaining(User user, Pageable page);
+
+    Page<User> findAllBySubscribersContainingOrderBySubscriptions(User user, Pageable page);
+
+    @Query("SELECT u FROM User u " +
+            "WHERE u.id <> ?2 AND 0 < (SELECT COUNT(e) FROM Event as e " +
+            "WHERE e.initiator.id = u.id AND e.state = ?1) " +
+            "ORDER BY u.subscribers.size DESC ")
+    Page<User> findAllInitiatorsByStateOrderBySubscribers(EventState state, long userId, Pageable page);
+
+    @Query("SELECT u FROM User u " +
+            "WHERE u.id <> ?2 AND NOT u IN ?3 AND 0 < (SELECT COUNT(e) FROM Event as e " +
+            "WHERE e.initiator.id = u.id AND e.state = ?1) " +
+            "ORDER BY u.subscribers.size DESC ")
+    Page<User> findAllAlienInitiatorsByStateOrderBySubscribers(EventState state, long user,
+                                                               Collection<User> subscriptions,
+                                                               Pageable page);
 }

--- a/explore-with-me-main_service/src/main/java/ru/practicum/service/EventService.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/service/EventService.java
@@ -2,11 +2,10 @@ package ru.practicum.service;
 
 import org.springframework.stereotype.Service;
 import ru.practicum.model.event.Event;
-import ru.practicum.model.event.EventSort;
 import ru.practicum.model.event.EventState;
 import ru.practicum.model.event.UpdateEventRequest;
+import ru.practicum.param.EventParam;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Set;
 
@@ -23,18 +22,7 @@ public interface EventService {
 
     Collection<Event> getEvents(int from, int size);
 
-    Collection<Event> searchEvents(Collection<Long> users,
-                                   Collection<EventState> states,
-                                   Collection<Long> categories,
-                                   LocalDateTime rangeStart, LocalDateTime rangeEnd,
-                                   int from, int size);
-
-    Collection<Event> searchEvents(String text,
-                                   Collection<Long> states,
-                                   Boolean paid,
-                                   LocalDateTime rangeStart, LocalDateTime rangeEnd,
-                                   Boolean onlyAvailable,
-                                   EventSort sort,
+    Collection<Event> searchEvents(EventParam eventParam,
                                    int from, int size);
 
     Event addEvent(long userId, long catId, Event category);

--- a/explore-with-me-main_service/src/main/java/ru/practicum/service/SubscriptionService.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/service/SubscriptionService.java
@@ -1,0 +1,22 @@
+package ru.practicum.service;
+
+import ru.practicum.model.event.Event;
+import ru.practicum.model.user.User;
+import ru.practicum.param.EventParam;
+
+import java.util.Collection;
+
+public interface SubscriptionService {
+
+    User addSubscription(long subscriberId, long userId);
+
+    void removeSubscription(long subscriberId, long userId);
+
+    Collection<User> getSubscriptions(long subscriberId, int from, int size);
+
+    Collection<User> getSubscribers(long userId, int from, int size);
+
+    Collection<Event> getSubscriptionEvents(long subscriberId, EventParam eventParam, int from, int size);
+
+    Collection<User> getInitiators(long userId, boolean onlyAliens, int from, int size);
+}

--- a/explore-with-me-main_service/src/main/java/ru/practicum/service/UserService.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/service/UserService.java
@@ -12,4 +12,6 @@ public interface UserService {
     User addUser(User user);
 
     void removeUser(long userId);
+
+    void validateUserExistsById(long userId);
 }

--- a/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/EventStatServiceImpl.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/EventStatServiceImpl.java
@@ -5,9 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import ru.practicum.model.event.Event;
-import ru.practicum.model.event.EventSort;
 import ru.practicum.model.event.EventState;
 import ru.practicum.model.event.UpdateEventRequest;
+import ru.practicum.param.EventParam;
 import ru.practicum.service.EventService;
 
 import java.time.LocalDateTime;
@@ -72,43 +72,15 @@ public class EventStatServiceImpl implements EventService {
     }
 
     @Override
-    public Collection<Event> searchEvents(Collection<Long> users,
-                                          Collection<EventState> states,
-                                          Collection<Long> categories,
-                                          LocalDateTime rangeStart, LocalDateTime rangeEnd,
+    public Collection<Event> searchEvents(EventParam eventParam,
                                           int from, int size) {
         log.debug("Invoked method searchEvents of class EventStatServiceImpl " +
-                        "with parameters: users = {}, states = {}, categories = {}, " +
-                        "rangeStart = {}, rangeEnd = {}, from = {}, size = {}",
-                users, states, categories, rangeStart, rangeEnd, from, size);
+                "with parameters: eventParam = {}, from = {}, size = {}", eventParam, from, size);
 
-        Collection<Event> events =
-                eventService.searchEvents(users, states, categories, rangeStart, rangeEnd, from, size);
-        initViews(events);
-
-        return events;
-    }
-
-    @Override
-    public Collection<Event> searchEvents(String text,
-                                          Collection<Long> categoriesId,
-                                          Boolean paid,
-                                          LocalDateTime rangeStart, LocalDateTime rangeEnd,
-                                          Boolean onlyAvailable,
-                                          EventSort sort,
-                                          int from, int size) {
-        log.debug("Invoked method searchEvents of class EventStatServiceImpl " +
-                        "with parameters: text = {}, categoriesId = {}, paid = {}, " +
-                        "rangeStart = {}, rangeEnd = {}, " +
-                        "onlyAvailable = {}, sort = {}, " +
-                        "from = {}, size = {}",
-                text, categoriesId, paid, rangeStart, rangeEnd, onlyAvailable, sort, from, size);
-
-        Collection<Event> events = eventService.searchEvents(text, categoriesId, paid, rangeStart, rangeEnd,
-                onlyAvailable, sort, from, size);
+        Collection<Event> events = eventService.searchEvents(eventParam, from, size);
 
         initViews(events);
-        switch (sort) {
+        switch (eventParam.getSort()) {
             case VIEWS:
                 events = events.stream().sorted(Comparator.comparing(Event::getViews)).collect(Collectors.toList());
                 break;

--- a/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/ParticipationRequestServiceImpl.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/ParticipationRequestServiceImpl.java
@@ -162,7 +162,7 @@ public class ParticipationRequestServiceImpl implements ParticipationRequestServ
     private Optional<ParticipationRequest> checkCanceledRequest(long userId, long eventId) {
         log.trace("Invoked method checkCanceledRequest of class ParticipationRequestServiceImpl " +
                 "with parameters: userId = {}, eventId = {};", userId, eventId);
-        return participationRequestRepository.findByEventIdAndEventInitiatorIdAndStatus(userId, eventId,
+        return participationRequestRepository.findByEventIdAndEventInitiatorIdAndStatus(eventId, userId,
                 ParticipationRequestStatus.CANCELED);
     }
 

--- a/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/SubscriptionServiceImpl.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/SubscriptionServiceImpl.java
@@ -1,0 +1,142 @@
+package ru.practicum.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.practicum.PageableGenerator;
+import ru.practicum.exception.InvalidActionException;
+import ru.practicum.exception.NotFoundException;
+import ru.practicum.model.event.Event;
+import ru.practicum.model.event.EventState;
+import ru.practicum.model.user.User;
+import ru.practicum.param.EventParam;
+import ru.practicum.repository.UserRepository;
+import ru.practicum.service.EventService;
+import ru.practicum.service.SubscriptionService;
+import ru.practicum.service.UserService;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubscriptionServiceImpl implements SubscriptionService {
+
+    private final UserService userService;
+    private final EventService eventService;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public User addSubscription(long subscriberId, long userId) {
+        log.debug("Invoked method addSubscription of class SubscriptionServiceImpl " +
+                "with parameters: subscriberId = {}, userId = {};", subscriberId, userId);
+
+        User subscriber = userService.getUser(subscriberId);
+        User user = userService.getUser(userId);
+
+        validateSubscriptionExists(subscriber, user);
+        subscriber.getSubscriptions().add(user);
+        return userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void removeSubscription(long subscriberId, long userId) {
+        log.debug("Invoked method addSubscription of class SubscriptionServiceImpl " +
+                "with parameters: subscriberId = {}, userId = {};", subscriberId, userId);
+        User subscriber = userService.getUser(subscriberId);
+        User user = userService.getUser(userId);
+
+        if (!subscriber.getSubscriptions().remove(user)) {
+            throw new NotFoundException("Subscription", userId);
+        }
+
+        userRepository.save(user);
+    }
+
+    @Override
+    public Collection<User> getSubscriptions(long subscriberId, int from, int size) {
+        log.debug("Invoked method getSubscriptions of class SubscriptionServiceImpl " +
+                "with parameters: subscriberId = {}, from = {}, size = {};", subscriberId, from, size);
+        User subscriber = userService.getUser(subscriberId);
+
+        return userRepository.findAllBySubscribersContainingOrderBySubscriptions(subscriber,
+                PageableGenerator.getPageable(from, size)).toSet();
+    }
+
+    @Override
+    public Collection<User> getSubscribers(long userId, int from, int size) {
+        log.debug("Invoked method getSubscribers of class SubscriptionServiceImpl " +
+                "with parameters: userId = {}, from = {}, size = {};", userId, from, size);
+        User user = userService.getUser(userId);
+        return userRepository.findAllBySubscriptionsContaining(user, PageableGenerator.getPageable(from, size)).toSet();
+    }
+
+    @Override
+    public Collection<Event> getSubscriptionEvents(long subscriberId, EventParam eventParam, int from, int size) {
+        log.debug("Invoked method getSubscribers of class SubscriptionServiceImpl " +
+                        "with parameters: subscriberId = {}, eventParam = {}, from = {}, size = {};",
+                subscriberId, eventParam, from, size);
+
+        User subscriber = userService.getUser(subscriberId);
+        validateSubscriptions(subscriber, eventParam.getInitiatorsId());
+
+        eventParam.setBySubscriber(subscriber);
+        eventParam.setStates(EventState.PUBLISHED);
+
+        return eventService.searchEvents(eventParam, from, size);
+    }
+
+    @Override
+    public Collection<User> getInitiators(long userId, boolean onlyAliens, int from, int size) {
+        log.debug("Invoked method getInitiators of class SubscriptionServiceImpl " +
+                "with parameters: userId = {}, onlyAliens ={}, from = {}, size = {};", userId, onlyAliens, from, size);
+
+        if (onlyAliens) {
+            return getAlienInitiators(userId, from, size);
+        } else {
+            userService.validateUserExistsById(userId);
+            return getInitiators(userId, from, size);
+        }
+    }
+
+    private Collection<User> getAlienInitiators(long userId, int from, int size) {
+        User user = userService.getUser(userId);
+        if (user.getSubscriptions().isEmpty()) {
+            return getInitiators(userId, from, size);
+        }
+        return userRepository.findAllAlienInitiatorsByStateOrderBySubscribers(EventState.PUBLISHED,
+                user.getId(), user.getSubscriptions(), PageableGenerator.getPageable(from, size)).toList();
+    }
+
+    private Collection<User> getInitiators(long userId, int from, int size) {
+        return userRepository.findAllInitiatorsByStateOrderBySubscribers(EventState.PUBLISHED, userId,
+                PageableGenerator.getPageable(from, size)).toList();
+    }
+
+    private void validateSubscriptionExists(User subscriber, User user) {
+        if (subscriber.getSubscriptions().contains(user)) {
+            throw new InvalidActionException(
+                    String.format("User with id = %d already subscribed to user with id = %d",
+                            subscriber.getId(), user.getId()));
+        }
+    }
+
+    private void validateSubscriptions(User subscriber, Collection<Long> users) {
+        if (users == null) {
+            return;
+        }
+        Collection<Long> subscriptions = subscriber.getSubscriptions().stream()
+                .map(User::getId)
+                .collect(Collectors.toList());
+
+        for (long userId : users) {
+            if (!subscriptions.contains(userId)) {
+                throw new NotFoundException("Subscription", userId);
+            }
+        }
+    }
+}

--- a/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/UserServiceImpl.java
+++ b/explore-with-me-main_service/src/main/java/ru/practicum/service/impl/UserServiceImpl.java
@@ -52,6 +52,7 @@ public class UserServiceImpl implements UserService {
         userRepository.deleteById(userId);
     }
 
+    @Override
     public void validateUserExistsById(long userId) {
         log.trace("Invoked method validateUserExistsById of class UserServiceImp " +
                 "with parameters: userId = {};", userId);

--- a/explore-with-me-main_service/src/main/resources/schema.sql
+++ b/explore-with-me-main_service/src/main/resources/schema.sql
@@ -52,4 +52,11 @@ CREATE TABLE IF NOT EXISTS events_compilations(
     event_id BIGINT REFERENCES events(id) NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS subscriptions(
+    subscriber_id BIGINT REFERENCES users(id) NOT NULL,
+    recipient_id BIGINT REFERENCES users(id) NOT NULL,
+    PRIMARY KEY(subscriber_id, recipient_id),
+    CHECK (subscriber_id <> recipient_id)
+);
+
 

--- a/postman/feature.json
+++ b/postman/feature.json
@@ -1,0 +1,1654 @@
+{
+	"info": {
+		"_postman_id": "e97aebd4-5118-40af-9140-638220bea8b1",
+		"name": "feature",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "27709893"
+	},
+	"item": [
+		{
+			"name": "prerequests",
+			"item": [
+				{
+					"name": "users",
+					"item": [
+						{
+							"name": "Add UserA",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test user 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 1').to.eql(1);\r",
+											"});\r",
+											"pm.test(\"Test user 'name' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('name');\r",
+											"    pm.expect(jsonData.name, '\"name\" must be \"UserA\"').to.eql('UserA');\r",
+											"});\r",
+											"pm.test(\"Test user 'email' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('email');\r",
+											"    pm.expect(jsonData.email, '\"email\" must be \"user.a@mail.ru\"').to.eql('user.a@mail.ru');\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"UserA\",\r\n    \"email\": \"user.a@mail.ru\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/admin/users",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add UserB",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test user 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 2').to.eql(2);\r",
+											"});\r",
+											"pm.test(\"Test user 'name' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('name');\r",
+											"    pm.expect(jsonData.name, '\"name\" must be \"UserB\"').to.eql('UserB');\r",
+											"});\r",
+											"pm.test(\"Test user 'email' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('email');\r",
+											"    pm.expect(jsonData.email, '\"email\" must be \"user.b@mail.ru\"').to.eql('user.b@mail.ru');\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"UserB\",\r\n    \"email\": \"user.b@mail.ru\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/admin/users",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add UserC",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test user 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 3').to.eql(3);\r",
+											"});\r",
+											"pm.test(\"Test user 'name' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('name');\r",
+											"    pm.expect(jsonData.name, '\"name\" must be \"UserC\"').to.eql('UserC');\r",
+											"});\r",
+											"pm.test(\"Test user 'email' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('email');\r",
+											"    pm.expect(jsonData.email, '\"email\" must be \"user.c@mail.ru\"').to.eql('user.c@mail.ru');\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"UserC\",\r\n    \"email\": \"user.c@mail.ru\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/admin/users",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"users"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "categories",
+					"item": [
+						{
+							"name": "Add category A",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test category 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 1').to.eql(1);\r",
+											"});\r",
+											"pm.test(\"Test category 'name' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('name');\r",
+											"    pm.expect(jsonData.name, '\"name\" must be \"Category A\"').to.eql('Category A');\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\":\"Category A\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/admin/categories",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add category B",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test category 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 2').to.eql(2);\r",
+											"});\r",
+											"pm.test(\"Test category 'name' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('name');\r",
+											"    pm.expect(jsonData.name, '\"name\" must be \"Category B\"').to.eql('Category B');\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\":\"Category B\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/admin/categories",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"categories"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "events",
+					"item": [
+						{
+							"name": "Add Event A to User A",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test event 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 1').to.eql(1);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"annotation\":\"Non nesciunt corrupti a deleniti laboriosam ut voluptatibus. Ut voluptas asperiores numquam voluptates. Consequatur eum commodi id ipsum aliquid neque fuga a. Consectetur non occaecati quia similique perferendis illum fugit optio. Provident autem ullam excepturi iure ipsum voluptas deleniti repellat officiis.\",\r\n    \"category\":1,\r\n    \"description\":\"Corrupti nam dolorem sed nobis necessitatibus. Quo atque quis dolor minima voluptatum. Ullam odit tempora cupiditate. Libero nobis qui culpa.\\n \\rEius ab aliquid. Eius alias enim et itaque. Delectus tempora sit soluta similique rerum ut laboriosam. Vitae qui hic sunt.\\n \\rSunt mollitia eaque laboriosam tempore sequi. Rem doloremque odio cupiditate id nisi debitis et ea unde. Dolore qui veritatis perferendis facere officiis fugit consequuntur. Commodi asperiores quam non consequatur sint voluptatibus ea. Sunt rem in nihil dolor quis nihil distinctio. Autem explicabo dolorum qui quidem ad et.\",\r\n    \"eventDate\":\"2024-11-05 20:26:22\",\r\n    \"location\":{\"lat\":-68.5542,\"lon\":17.3736},\r\n    \"paid\":\"false\",\r\n    \"participantLimit\":\"0\",\r\n    \"requestModeration\":\"false\",\r\n    \"title\":\"Event A\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/users/:userId/events",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"users",
+										":userId",
+										"events"
+									],
+									"variable": [
+										{
+											"key": "userId",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add Event B to User A",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test event 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 2').to.eql(2);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"annotation\":\"Non nesciunt corrupti a deleniti laboriosam ut voluptatibus. Ut voluptas asperiores numquam voluptates. Consequatur eum commodi id ipsum aliquid neque fuga a. Consectetur non occaecati quia similique perferendis illum fugit optio. Provident autem ullam excepturi iure ipsum voluptas deleniti repellat officiis.\",\r\n    \"category\":1,\r\n    \"description\":\"Corrupti nam dolorem sed nobis necessitatibus. Quo atque quis dolor minima voluptatum. Ullam odit tempora cupiditate. Libero nobis qui culpa.\\n \\rEius ab aliquid. Eius alias enim et itaque. Delectus tempora sit soluta similique rerum ut laboriosam. Vitae qui hic sunt.\\n \\rSunt mollitia eaque laboriosam tempore sequi. Rem doloremque odio cupiditate id nisi debitis et ea unde. Dolore qui veritatis perferendis facere officiis fugit consequuntur. Commodi asperiores quam non consequatur sint voluptatibus ea. Sunt rem in nihil dolor quis nihil distinctio. Autem explicabo dolorum qui quidem ad et.\",\r\n    \"eventDate\":\"2024-11-05 20:26:22\",\r\n    \"location\":{\"lat\":-68.5542,\"lon\":17.3736},\r\n    \"paid\":\"false\",\r\n    \"participantLimit\":\"1\",\r\n    \"requestModeration\":\"false\",\r\n    \"title\":\"Event B\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/users/:userId/events",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"users",
+										":userId",
+										"events"
+									],
+									"variable": [
+										{
+											"key": "userId",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add Event C to User C",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test event 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 3').to.eql(3);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"annotation\":\"Non nesciunt corrupti a deleniti laboriosam ut voluptatibus. Ut voluptas asperiores numquam voluptates. Consequatur eum commodi id ipsum aliquid neque fuga a. Consectetur non occaecati quia similique perferendis illum fugit optio. Provident autem ullam excepturi iure ipsum voluptas deleniti repellat officiis.\",\r\n    \"category\":1,\r\n    \"description\":\"Corrupti nam dolorem sed nobis necessitatibus. Quo atque quis dolor minima voluptatum. Ullam odit tempora cupiditate. Libero nobis qui culpa.\\n \\rEius ab aliquid. Eius alias enim et itaque. Delectus tempora sit soluta similique rerum ut laboriosam. Vitae qui hic sunt.\\n \\rSunt mollitia eaque laboriosam tempore sequi. Rem doloremque odio cupiditate id nisi debitis et ea unde. Dolore qui veritatis perferendis facere officiis fugit consequuntur. Commodi asperiores quam non consequatur sint voluptatibus ea. Sunt rem in nihil dolor quis nihil distinctio. Autem explicabo dolorum qui quidem ad et.\",\r\n    \"eventDate\":\"2024-11-05 20:26:22\",\r\n    \"location\":{\"lat\":-68.5542,\"lon\":17.3736},\r\n    \"paid\":\"false\",\r\n    \"participantLimit\":\"2\",\r\n    \"requestModeration\":\"false\",\r\n    \"title\":\"Event C\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/users/:userId/events",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"users",
+										":userId",
+										"events"
+									],
+									"variable": [
+										{
+											"key": "userId",
+											"value": "3"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Confirm Event A",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test event 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 1').to.eql(1);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test event 'state' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('state');\r",
+											"    pm.expect(jsonData.state, '\"state\" must be PUBLISHED').to.eql('PUBLISHED');\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"stateAction\": \"PUBLISH_EVENT\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/admin/events/:eventId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"events",
+										":eventId"
+									],
+									"variable": [
+										{
+											"key": "eventId",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Confirm Event C",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {\r",
+											"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+											"});\r",
+											"pm.test(\"Has create response\", function () {\r",
+											"    pm.response.to.be.withBody;\r",
+											"    pm.response.to.be.json;\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test event 'id' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('id');\r",
+											"    pm.expect(jsonData.id, '\"id\" must be 3').to.eql(3);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Test event 'state' field\", function () {\r",
+											"    var jsonData = pm.response.json();\r",
+											"    pm.expect(jsonData).to.have.property('state');\r",
+											"    pm.expect(jsonData.state, '\"state\" must be PUBLISHED').to.eql('PUBLISHED');\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"stateAction\": \"PUBLISH_EVENT\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/admin/events/:eventId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"events",
+										":eventId"
+									],
+									"variable": [
+										{
+											"key": "eventId",
+											"value": "3"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "subscription",
+			"item": [
+				{
+					"name": "User B add subscription A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('id');\r",
+									"    pm.expect(jsonData.id, '\"id\" must be 1').to.eql(1);\r",
+									"});\r",
+									"pm.test(\"Test user 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('name');\r",
+									"    pm.expect(jsonData.name, '\"name\" must be \"UserA\"').to.eql('UserA');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "1"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B add subscription A duplicated",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 409\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([409]);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "1"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User A add Ivalid subscription",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([404]);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=99",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "99"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B subscriptions updated",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('id');\r",
+									"    pm.expect(jsonData[0].id, '\"id\" must be 1').to.eql(1);\r",
+									"});\r",
+									"pm.test(\"Test user 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('name');\r",
+									"    pm.expect(jsonData[0].name, '\"name\" must be \"UserA\"').to.eql('UserA');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User A subscribers updated",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('id');\r",
+									"    pm.expect(jsonData[0].id, '\"id\" must be 2').to.eql(2);\r",
+									"});\r",
+									"pm.test(\"Test user 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('name');\r",
+									"    pm.expect(jsonData[0].name, '\"name\" must be \"UserB\"').to.eql('UserB');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscribers",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscribers"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B delete subscription A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([204]);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "1"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User A subscribers empty",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test list user response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.length, 'List length must be empty').to.eql(0);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscribers",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscribers"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B subscriptions empty",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test list user response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.length, 'List length must be empty').to.eql(0);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B delete subscription A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([404]);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "1"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B get initiators",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user a 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('id');\r",
+									"    pm.expect(jsonData[0].id, '\"id\" must be 1').to.eql(1);\r",
+									"});\r",
+									"pm.test(\"Test user a 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('name');\r",
+									"    pm.expect(jsonData[0].name, '\"name\" must be \"UserA\"').to.eql('UserA');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user c 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[1]).to.have.property('id');\r",
+									"    pm.expect(jsonData[1].id, '\"id\" must be 3').to.eql(3);\r",
+									"});\r",
+									"pm.test(\"Test user c 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[1]).to.have.property('name');\r",
+									"    pm.expect(jsonData[1].name, '\"name\" must be \"UserC\"').to.eql('UserC');\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/initiators",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"initiators"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User C get initiators",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user a 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('id');\r",
+									"    pm.expect(jsonData[0].id, '\"id\" must be 1').to.eql(1);\r",
+									"});\r",
+									"pm.test(\"Test user a 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('name');\r",
+									"    pm.expect(jsonData[0].name, '\"name\" must be \"UserA\"').to.eql('UserA');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/initiators",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"initiators"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "3"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B add subscription A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('id');\r",
+									"    pm.expect(jsonData.id, '\"id\" must be 1').to.eql(1);\r",
+									"});\r",
+									"pm.test(\"Test user 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('name');\r",
+									"    pm.expect(jsonData.name, '\"name\" must be \"UserA\"').to.eql('UserA');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "1"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User get alien initiators",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user c 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('id');\r",
+									"    pm.expect(jsonData[0].id, '\"id\" must be 3').to.eql(3);\r",
+									"});\r",
+									"pm.test(\"Test user c 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('name');\r",
+									"    pm.expect(jsonData[0].name, '\"name\" must be \"UserC\"').to.eql('UserC');\r",
+									"});\r",
+									"\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/initiators?onlyAliens=true",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"initiators"
+							],
+							"query": [
+								{
+									"key": "onlyAliens",
+									"value": "true"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B get subscription events",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test list events response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.length, 'List length must be 1').to.eql(1);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user c 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData[0]).to.have.property('id');\r",
+									"    pm.expect(jsonData[0].id, '\"id\" must be 1').to.eql(1);\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions/events?",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions",
+								"events"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": null
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B add subscription C",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('id');\r",
+									"    pm.expect(jsonData.id, '\"id\" must be 3').to.eql(3);\r",
+									"});\r",
+									"pm.test(\"Test user 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('name');\r",
+									"    pm.expect(jsonData.name, '\"name\" must be \"UserC\"').to.eql('UserC');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=3",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "3"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User C add subscription A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([201]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test user 'id' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('id');\r",
+									"    pm.expect(jsonData.id, '\"id\" must be 1').to.eql(1);\r",
+									"});\r",
+									"pm.test(\"Test user 'name' field\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property('name');\r",
+									"    pm.expect(jsonData.name, '\"name\" must be \"UserA\"').to.eql('UserA');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions?initiatorId=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions"
+							],
+							"query": [
+								{
+									"key": "initiatorId",
+									"value": "1"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "3"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B get subscription events",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test list events response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.length, 'List length must be 2').to.eql(2);\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions/events?",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions",
+								"events"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": null
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User B get subscription events User A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test list events response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.length, 'List length must be 1').to.eql(1);\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions/events?subscriptions=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions",
+								"events"
+							],
+							"query": [
+								{
+									"key": "subscriptions",
+									"value": "1"
+								},
+								{
+									"key": "categoriesId",
+									"value": "1",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "User C get subscription events",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+									"});\r",
+									"pm.test(\"Has create response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Test list events response\", function () {\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.length, 'List length must be 1').to.eql(1);\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/subscriptions/events?",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"subscriptions",
+								"events"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": null
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "3"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:8080"
+		}
+	]
+}


### PR DESCRIPTION
Этап 3. Фича - подписки.
    Добавленный функционал по моему мнению достаточно мал, однако я постарался проработать его глубину. Был вариант с добавлением "друзей", однако на этапе повторной планировки (после добавления функционала подписок) я пришел к выводу, что логика слишком сложна и она начнёт в некотором смысле ломать приложение.
Нынешний функционал подразумевает следующий список возможностей через эндпоинты:
- Получение списка "публикаторов";
- Добавление подписки (можно добавлять пользователей без публичных событий. Исходил из того, что друзья могут делиться информацией и таким образом подписаться друг на друга).
- Удаление подписки
- Получение списка подписок
- Получение списка событий от подписок (по фильтрам). Данный пункт я не проверял досконально через тесты по всем фильтрам в связи с тем, что работоспособность непроверенных пунктов напрямую зависела от основных тестов (см. дальше). Также выключена сортировка по причине её и так неверной работы по причине особенной логики поля views, тема которого поднималась наставников на одном из вебинаров.
    Был изменен формат передачи "параметров" поиска события (метод search в EventService). По рекомендациям наставника создан EventParam, однако видоизмененный. Основная цель класса - создать предикат через сложение всех "фильтров" с использованием "и" как промежуточного. Это накладывает определённые ограничения и заставляет контроллер вмешиваться в логику программы (видно на примере класса PrivateSubscriberController, где дважды вносятся изменения в EventParam в контроллере, а потом в сервисе). Однако это позволило разгрузить классы сервисов и сделать общий подход для всех запросов на множество необязательных параметров. Считаю, что это меньшее из зол. Также можно постановить, что если фильтр работает корректно, то он будет работать также и далее.
    Касательно EventParam и почему он существует преимущественно для предиката. Добавлю, что он легко расширяется в контексте "переноса" данных на нижние слои (сервисы). Достаточно добавить 2-3 строчки. А возвращаясь к предыдущему вопросу, я подразумеваю, что корректных запросов будет значительно больше тех, что могут вызвать ошибку, и не проверять каждое поле класса на null вижу маленькой оптимизационной победой без особого вреда для архитектуры.
    Добавлю, что я не смог написать "универсальные" тесты, которые были предоставлены Яндекс практикум для проверки своего функционала, из-за чего тесты на git не проходятся, так как требуется запуск моих тестов первыми.